### PR TITLE
Allow base-4.19, aeson-2.2, tasty-15; add attoparsec-aeson for benchmark

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16
+# version: 0.17.20231010
 #
-# REGENDATA ("0.16",["github","cabal.project"])
+# REGENDATA ("0.17.20231010",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,19 +32,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.4.7
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -120,7 +125,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -129,7 +134,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -145,10 +150,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -216,8 +223,8 @@ jobs:
       - name: install cabal-docspec
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20230406/cabal-docspec-0.0.0.20230406-x86_64-linux.xz > cabal-docspec.xz
-          echo '68fa9addd5dc453d533a74a763950499d4593b1297c9a05c3ea5bd1acc04c9dd  cabal-docspec.xz' | sha256sum -c -
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20230517/cabal-docspec-0.0.0.20230517-x86_64-linux.xz > cabal-docspec.xz
+          echo '3b31bbe463ad4d671abbc103db49628562ec48a6604cab278207b5b6acd21ed7  cabal-docspec.xz' | sha256sum -c -
           xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
           rm -f cabal-docspec.xz
           chmod a+x $HOME/.cabal/bin/cabal-docspec
@@ -298,10 +305,14 @@ jobs:
           rm -f cabal.project.local
       - name: constraint set intersection
         run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='rere +rere-intersection' all --dry-run
+          cabal-plan topo | sort
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='rere +rere-intersection' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='rere +rere-intersection' all
       - name: constraint set no-cfg
         run: |
+          if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='rere -rere-cfg' all --dry-run ; fi
+          if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
           if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='rere -rere-cfg' --dependencies-only -j2 all ; fi
           if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='rere -rere-cfg' all ; fi
       - name: save cache

--- a/rere.cabal
+++ b/rere.cabal
@@ -33,9 +33,10 @@ tested-with:
    || ==8.8.4
    || ==8.10.7
    || ==9.0.2
-   || ==9.2.7
-   || ==9.4.4
-   || ==9.6.1
+   || ==9.2.8
+   || ==9.4.7
+   || ==9.6.3
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -61,7 +62,7 @@ library
 
   -- GHC boot libraries
   build-depends:
-    , base          >=4.3.0.0  && <4.19
+    , base          >=4.3.0.0  && <4.20
     , containers    ^>=0.4.0.0 || ^>=0.5.0.0 || ^>=0.6.0.1
     , parsec        ^>=3.1.12.0
     , transformers  ^>=0.3.0.0 || ^>=0.4.2.0 || ^>=0.5.2.0 || ^>=0.6.1.0
@@ -146,8 +147,10 @@ benchmark json
   other-modules:    DerpConv
   ghc-options:      -Wall -rtsopts
   build-depends:
-    , aeson       ^>=1.4.6.0 || ^>=1.5.0.0 || ^>=2.0.0.0 || ^>=2.1.0.0
+    , aeson       ^>=1.4.6.0 || ^>=1.5.0.0 || ^>=2.0.0.0 || ^>=2.1.0.0 || ^>=2.2.1.0
     , attoparsec
+    , attoparsec-aeson
+                  ^>=2.1.0.0 || ^>=2.2.0.1
     , base
     , bytestring
     , clock       ^>=0.8
@@ -182,7 +185,7 @@ test-suite properties
     , QuickCheck
     , quickcheck-instances  ^>=0.3.22
     , rere
-    , tasty                 ^>=1.4.0.1
+    , tasty                 ^>=1.4.0.1 || ^>=1.5
     , tasty-quickcheck      ^>=0.10.1.1
 
   if flag(rere-intersection)


### PR DESCRIPTION
Closes #23.

Release required because of added dep.
